### PR TITLE
Set up Autotools build for Guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Autotools generated files
+/Makefile
+/Makefile.in
+/configure
+/config.log
+/config.status
+/aclocal.m4
+/autom4te.cache/
+/compile
+/depcomp
+/install-sh
+/missing
+/*.log
+
+# Build artifacts
+Guard/Guard/Makefile
+Guard/Guard/Makefile.in
+Guard/Guard/.deps/
+Guard/Guard/Guard
+Guard/Guard/*.o

--- a/Guard/Guard/Makefile.am
+++ b/Guard/Guard/Makefile.am
@@ -1,0 +1,4 @@
+bin_PROGRAMS = Guard
+Guard_SOURCES = main.c guard_main.c error.c change_to_user.c
+Guard_CPPFLAGS = -I$(srcdir)
+Guard_LDADD = -lpthread

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = Guard/Guard

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,6 @@
+AC_INIT([Guard], [0.1])
+AM_INIT_AUTOMAKE([foreign])
+AC_PROG_CC
+AC_CONFIG_SRCDIR([Guard/Guard/main.c])
+AC_CONFIG_FILES([Makefile Guard/Guard/Makefile])
+AC_OUTPUT

--- a/plan_wip.txt
+++ b/plan_wip.txt
@@ -7,6 +7,9 @@ Goals
 - Establish on‑disk structure under `/opt/c4a` (ro settings, memory, logs) without requiring admin for local dev.
 
 Milestones
+0) Build System Setup
+   - Introduce Autoconf/Automake scripts to compile Guard.
+   - Acceptance: `./configure && make` builds Guard binary.
 1) Bootstrap & Process Detection
    - Harden `scripts/pcheck.sh` (implement name/command/external; stub url for now).
    - Fix logging wrapper `scripts/c4a_script_logging` to use system `logger` correctly.


### PR DESCRIPTION
## Summary
- add Autoconf and Automake scripts to build Guard
- document new build system in plan
- ignore generated build artifacts

## Testing
- `autoreconf -i`
- `./configure`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689f3fecbb908320be3d3fbe30febe10